### PR TITLE
chat parse 처리 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /build/
 /build/classes/java/main/
 /.idea/
+/release
+local.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,26 @@ repositories {
     }
 }
 
+//junit5
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+dependencies {
+    // (Required) Writing and executing Unit Tests on the JUnit Platform
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
+
+    // (Optional) If you need "Parameterized Tests"
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.2")
+
+    // (Optional) If you also have JUnit 4-based tests
+    testImplementation("junit:junit:4.13.2")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.8.2")
+}
+//truth
+dependencies {
+    testImplementation("com.google.truth:truth:1.1.3")
+}
 @Suppress("VulnerableLibrariesLocal")
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,36 +15,12 @@ repositories {
     }
 }
 
-//junit5
+application {
+    mainClass.set("MainKt")
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
-}
-dependencies {
-    // (Required) Writing and executing Unit Tests on the JUnit Platform
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
-
-    // (Optional) If you need "Parameterized Tests"
-    testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.2")
-
-    // (Optional) If you also have JUnit 4-based tests
-    testImplementation("junit:junit:4.13.2")
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.8.2")
-}
-//truth
-dependencies {
-    testImplementation("com.google.truth:truth:1.1.3")
-}
-@Suppress("VulnerableLibrariesLocal")
-dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:1.7.20")
-    implementation("io.ktor:ktor-server-core:2.2.1")
-    implementation("io.ktor:ktor-server-netty:2.2.1")
-    implementation("commons-io:commons-io:2.11.0")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:1.7.20")
-    testImplementation("io.strikt:strikt-core:0.34.1")
-    // implementation("org.jetbrains.compose.compiler:compiler-hosted:1.2.0")
 }
 
 tasks.withType<KotlinCompile> {
@@ -54,6 +30,19 @@ tasks.withType<KotlinCompile> {
     }
 }
 
-application {
-    mainClass.set("MainKt")
+@Suppress("VulnerableLibrariesLocal")
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.7.20")
+    implementation("io.ktor:ktor-server-core:2.2.1")
+    implementation("io.ktor:ktor-server-netty:2.2.1")
+    implementation("commons-io:commons-io:2.11.0")
+
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.7.20")
+    testImplementation("io.strikt:strikt-core:0.34.1")
+    testImplementation("com.google.truth:truth:1.1.3")
+    // implementation("org.jetbrains.compose.compiler:compiler-hosted:1.2.0")
 }
+

--- a/src/main/kotlin/kakaotalk-talk-analyze.kt
+++ b/src/main/kotlin/kakaotalk-talk-analyze.kt
@@ -1,10 +1,8 @@
-@file:Suppress("ConstPropertyName")
-
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 
-private const val Debug = false
+private const val DEBUG = true
 
 val dateFormatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
 
@@ -14,6 +12,7 @@ fun main() {
     val targetFile = File("release/KakaoTalk_Chat.csv")
     val reportFile = File("release/report.txt").also { it.delete() }
     val errorFile = File("release/error.txt").also { it.delete() }
+    val filterMessages = listOf("님을 내보냈습니다", "님이 나갔습니다", "님이 들어왔습니다")
 
     targetFile.readText()
         .split("\n(?=\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})".toRegex())
@@ -23,23 +22,20 @@ fun main() {
             runCatching {
                 Chat(
                     date = dateFormatter.parse(chat.getOrNull(0)).time,
-                    name = chat.getOrNull(1)?.trim('"') ?: "",
-                    message = chat.getOrNull(2) ?: ""
-                )
-            }.getOrElse {
-                if (Debug) {
-                    errorFile.appendText(chat.toString())
-                    errorFile.appendText(it.toString())
+                    name = chat.getOrNull(1)?.trim('"').orEmpty(),
+                    message = chat.getOrNull(2).orEmpty(),
+                ).let { chat ->
+                    chat.takeIf { !filterMessages.any { chat.message.contains(it) } }
                 }
+            }.getOrElse { exception ->
+                if (DEBUG) errorFile.appendText("[$chat] $exception\n")
                 null
             }
         }
-        .filterNot { it.message.contains("${it.name}님을 내보냈습니다") || it.message.contains("${it.name}님이 나갔습니다.") || it.message.contains("${it.name}님이 들어왔습니다.") }
         .groupBy { it.name }
         .mapNotNull { (_, chats) -> chats.maxByOrNull { it.date } }
         .sortedByDescending { it.date }
         .mapIndexed { index, chat -> "${index + 1}:${dateFormatter.format(Date(chat.date))}:${chat.name}" }
         .onEach { println(it) }
-        .toList()
         .also { reportFile.writeText(it.joinToString("\n")) }
 }

--- a/src/main/kotlin/kakaotalk-talk-analyze.kt
+++ b/src/main/kotlin/kakaotalk-talk-analyze.kt
@@ -3,76 +3,43 @@
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
 
 private const val Debug = false
 
-val dateFormatter = SimpleDateFormat("yyyy. M. dd. aa h:mm", Locale.KOREA)
+val dateFormatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+
+data class Chat(val date: Long, val name: String, val message: String)
 
 fun main() {
-    val targetFile = File("/Users/jisungbin/Downloads/chat/katalk.txt")
-    val targetLines = targetFile.readLines()
-    val targrtWholeText = targetFile.readText()
+    val targetFile = File("release/KakaoTalk_Chat.csv")
+    val reportFile = File("release/report.txt").also { it.delete() }
+    val errorFile = File("release/error.txt").also { it.delete() }
 
-    val reportFile = File("/Users/jisungbin/Downloads/chat/report.txt").also {
-        if (it.exists()) it.delete()
-    }
-    val errorFile = File("/Users/jisungbin/Downloads/chat/error.txt").also {
-        if (it.exists()) it.delete()
-    }
-
-    val chats = mutableMapOf<String, MutableList<Pair<Date, String>>>()
-    val errors = mutableListOf<String>()
-    val leaveCheckResult = mutableMapOf<String, Boolean>()
-
-    targetLines.forEach { line ->
-        try {
-            val dateString = line.split(",")[0]
-            val name = line.split(", ")[1].split(" :")[0]
-            val message = line.split(" : ")[1]
-            val date = dateFormatter.parse(dateString)
-            // if (leaveCheckResult[name] == null) {
-            //     leaveCheckResult[name] =
-            //         targrtWholeText.contains("${name}님을 내보냈습니다") || targrtWholeText.contains("${name}님이 나갔습니다")
-            // }
-            @Suppress("ConstantConditionIf")
-            if (true) {
-                chats.compute(name) { _, chats ->
-                    val value = date to message
-                    chats?.apply { add(value) } ?: mutableListOf(value)
-                }
-            }
-        } catch (error: Exception) {
-            if (!errorFile.exists()) {
-                errorFile.createNewFile()
-            }
-            errors.add(
-                """
-                    |error: ${error.message}
-                    |line: $line
-                """.trimMargin()
-            )
-        }
-    }
-    errorFile.writeText(errors.joinToString("\n\n"))
-    if (!Debug) {
-        val result = buildList {
-            chats.forEach { (name, messages) ->
-                add(
-                    """
-                    name: $name
-                    last message: ${messages.last().second}
-                    last time: ${messages.last().first.let { dateFormatter.format(it) }}
-                    message count: ${messages.size}
-                    """.trimIndent() to messages.last().first
+    targetFile.readText()
+        .split("\n(?=\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})".toRegex())
+        .asSequence()
+        .map { it.split(",", limit = 3) }
+        .mapNotNull { chat ->
+            runCatching {
+                Chat(
+                    date = dateFormatter.parse(chat.getOrNull(0)).time,
+                    name = chat.getOrNull(1)?.trim('"') ?: "",
+                    message = chat.getOrNull(2) ?: ""
                 )
+            }.getOrElse {
+                if (Debug) {
+                    errorFile.appendText(chat.toString())
+                    errorFile.appendText(it.toString())
+                }
+                null
             }
         }
-        result.sortedBy { it.second }.let { report ->
-            if (!reportFile.exists()) {
-                reportFile.createNewFile()
-            }
-            reportFile.writeText(report.joinToString("\n\n") { it.first })
-        }
-    }
+        .filterNot { it.message.contains("${it.name}님을 내보냈습니다") || it.message.contains("${it.name}님이 나갔습니다.") || it.message.contains("${it.name}님이 들어왔습니다.") }
+        .groupBy { it.name }
+        .mapNotNull { (_, chats) -> chats.maxByOrNull { it.date } }
+        .sortedByDescending { it.date }
+        .mapIndexed { index, chat -> "${index + 1}:${dateFormatter.format(Date(chat.date))}:${chat.name}" }
+        .onEach { println(it) }
+        .toList()
+        .also { reportFile.writeText(it.joinToString("\n")) }
 }

--- a/src/test/kotlin/DateParseTest.kt
+++ b/src/test/kotlin/DateParseTest.kt
@@ -10,14 +10,15 @@ import util.buildDate
 class DateParseTest {
     @Test
     fun `오전 시간`() {
-        val dateString = "2022. 9. 16. 오전 9:49"
+        val dateString = "2021-12-25 18:52:27"
         val actual = dateFormatter.parse(dateString)
         val expected = buildDate(
-            year = 2022,
-            month = 8,
-            day = 16,
-            hour = 9,
-            minute = 49,
+            year = 2021,
+            month = 11,
+            day = 25,
+            hour = 18,
+            minute = 52,
+            second = 27,
         )
 
         expectThat(actual).withNotNull {
@@ -35,14 +36,15 @@ class DateParseTest {
 
     @Test
     fun `오후 시간`() {
-        val dateString = "2022. 12. 16. 오후 9:49"
+        val dateString = "2021-12-25 8:52:27"
         val actual = dateFormatter.parse(dateString)
         val expect = buildDate(
-            year = 2022,
+            year = 2021,
             month = 11,
-            day = 16,
-            hour = 21,
-            minute = 49,
+            day = 25,
+            hour = 8,
+            minute = 52,
+            second = 27,
         )
 
         expectThat(actual).withNotNull {

--- a/src/test/kotlin/KakaotalkTalkAnalyzeTest.kt
+++ b/src/test/kotlin/KakaotalkTalkAnalyzeTest.kt
@@ -1,44 +1,18 @@
-import com.google.common.truth.Truth
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import java.io.File
 
-internal class Kakaotalk_talk_analyzeKtTest {
-
-    @BeforeEach
-    fun setUp() {
-    }
-
-    @AfterEach
-    fun tearDown() {
-    }
-
-    @Test
-    @DisplayName("현제위치 확인")
-    fun main() {
-        //given
-        val currentFile = File("release/KakaoTalk_Chat.csv")
-
-        //when
-        val actual = currentFile.absoluteFile.toString()
-
-        //then
-        Truth.assertThat(actual).isEqualTo("/Users/user/work/JvmPlayground/release/KakaoTalk_Chat.csv")
-    }
-
+class KakaotalkTalkAnalyzeTest {
     @Test
     @DisplayName("cvs parse")
-    fun splitcvs(){
+    fun splitcvs() {
         val s = "John Doe, 13, \"Subject 1, Subject 2, Subject 3\""
-        var list: List<String> = s.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)".toRegex())
+        val list: List<String> = s.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)".toRegex())
         println(list)
     }
 
     @Test
     @DisplayName("cvs parse multi line")
-    fun splitcvs2(){
+    fun splitcvs2() {
         val s = """
             2022-11-07 16:00:19,"aaaaaaaaaaa","LazyVerticalGrid를 LazyColumn 안에 넣어서 parent인 LazyColumn단만 스크롤되게 하고싶은데 어떻게 해야할까요 지금 문제는 뷰를 그리는 과정에서 LazyVerticalGrid의 크기를 구하지 못해서 에러가 나는 상황입니다..ㅠㅠ"
             2022-11-07 16:01:27,"bbbb","혹시 super 전에 작성하셨을까요?"
@@ -47,8 +21,8 @@ internal class Kakaotalk_talk_analyzeKtTest {
             2022-11-07 16:12:21,"cccc","super.onCreate(savedInstanceState) 네 이 메서드 전에 작성했습니다"
             2022-11-08 17:23:56,"dddd","사진"
         """.trimIndent()
-        val list: List<String> = s.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)|\n".toRegex())//90000글자 정도에서 에러남 정규식 사용불가
+        val list: List<String> = s.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)|\n".toRegex()) // 90000글자 정도에서 에러남 정규식 사용불가
         println(list.size)
-        list.forEach { println(it.replace("\n","\\n")) }
+        list.forEach { println(it.replace("\n", "\\n")) }
     }
 }

--- a/src/test/kotlin/Kakaotalk_talk_analyzeKtTest.kt
+++ b/src/test/kotlin/Kakaotalk_talk_analyzeKtTest.kt
@@ -1,0 +1,54 @@
+import com.google.common.truth.Truth
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.File
+
+internal class Kakaotalk_talk_analyzeKtTest {
+
+    @BeforeEach
+    fun setUp() {
+    }
+
+    @AfterEach
+    fun tearDown() {
+    }
+
+    @Test
+    @DisplayName("현제위치 확인")
+    fun main() {
+        //given
+        val currentFile = File("release/KakaoTalk_Chat.csv")
+
+        //when
+        val actual = currentFile.absoluteFile.toString()
+
+        //then
+        Truth.assertThat(actual).isEqualTo("/Users/user/work/JvmPlayground/release/KakaoTalk_Chat.csv")
+    }
+
+    @Test
+    @DisplayName("cvs parse")
+    fun splitcvs(){
+        val s = "John Doe, 13, \"Subject 1, Subject 2, Subject 3\""
+        var list: List<String> = s.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)".toRegex())
+        println(list)
+    }
+
+    @Test
+    @DisplayName("cvs parse multi line")
+    fun splitcvs2(){
+        val s = """
+            2022-11-07 16:00:19,"aaaaaaaaaaa","LazyVerticalGrid를 LazyColumn 안에 넣어서 parent인 LazyColumn단만 스크롤되게 하고싶은데 어떻게 해야할까요 지금 문제는 뷰를 그리는 과정에서 LazyVerticalGrid의 크기를 구하지 못해서 에러가 나는 상황입니다..ㅠㅠ"
+            2022-11-07 16:01:27,"bbbb","혹시 super 전에 작성하셨을까요?"
+            2022-11-07 16:06:33,"bbbb","1. userScrollEnabled 인자로 스크롤 여부를 조정할 수 있습니다
+            2. Modifier.onPlaced 로 컴포저블이 배치됐을 때 크기를 구할 수 있습니다"
+            2022-11-07 16:12:21,"cccc","super.onCreate(savedInstanceState) 네 이 메서드 전에 작성했습니다"
+            2022-11-08 17:23:56,"dddd","사진"
+        """.trimIndent()
+        val list: List<String> = s.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)|\n".toRegex())//90000글자 정도에서 에러남 정규식 사용불가
+        println(list.size)
+        list.forEach { println(it.replace("\n","\\n")) }
+    }
+}


### PR DESCRIPTION
무엇을 :
1. chat 내용에 LF 가 있는 경우 라인단위로 처리가 불가함

어떻게 : 
1. chating 한번을 나누는 방법 및 기준을 변경함
2. 날짜포멧형식앞에 LF를 기준으로 채팅을 구분함
3. test code를 위한 truth, junit5추가
4. 경로를 상대위치로 변경함 {project root} / release
5. kakao pc 버전에서 chat 내용을 다운로드 받아 처리
6. chat내용중 들어왔음은 무시 추가

왜 :
1. 정규식을 사용하면 data량이 커지면 죽음
2. cvs포멧이라 line단위 처리가 불가